### PR TITLE
Add conda-env if this buildpack is replacing another conda buildback without conda-env

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -91,6 +91,7 @@ PYTHONPATH='/app/.heroku/miniconda/lib/python2.7/site-packages:$PYTHONPATH'
 if [ -f environment.yml ]; then
   PYTHONPATH="/app/.heroku/miniconda/envs/heroku-env/lib/python2.7/site-packages:${PYTHONPATH}"
   set-default-env CONDA_DEFAULT_ENV "heroku-env"
+  set-env PATH '$HOME/.heroku/miniconda/envs/heroku-env/bin:$PATH'
 fi
 set-default-env PYTHONPATH $PYTHONPATH
 set-env PYTHONUNBUFFERED true

--- a/bin/steps/conda_compile
+++ b/bin/steps/conda_compile
@@ -9,6 +9,7 @@ if [ ! -d /app/.heroku/miniconda ]; then
     conda update conda --quiet --yes | indent
 fi
 
+conda environment --help || conda update conda --quiet --yes | indent
 
 if [ -f conda-requirements.txt ]; then
     puts-step "Installing dependencies using Conda"

--- a/bin/steps/conda_compile
+++ b/bin/steps/conda_compile
@@ -21,7 +21,7 @@ if [ -f environment.yml ]; then
     puts-step "Creating conda environment"
     # TODO: Use update if its already there
     conda env remove --yes --quiet --name heroku-env
-    conda env create -v --name=heroku-env --file environment.yml
+    conda env create --name=heroku-env --file environment.yml
 fi
 
 # Clean up the installation environment .

--- a/bin/steps/conda_compile
+++ b/bin/steps/conda_compile
@@ -25,7 +25,7 @@ if [ -f environment.yml ]; then
     puts-step "Conda environment created"
     source activate heroku-env
     # conda install --yes nomkl numpy
-    conda remove --yes mkl mkl-service
+    # conda remove --yes mkl mkl-service
 fi
 
 # Clean up the installation environment .

--- a/bin/steps/conda_compile
+++ b/bin/steps/conda_compile
@@ -1,8 +1,9 @@
 #!/usr/bin/env bash
-CONDA_VERSION=3.8.3
+CONDA_VERSION=4.3.31
+puts-step "Checking for existing conda install"
 if [ ! -d /app/.heroku/miniconda ]; then
     puts-step "Preparing Python/Miniconda Environment (${CONDA_VERSION})"
-    curl -Os http://repo.continuum.io/miniconda/Miniconda-${CONDA_VERSION}-Linux-x86_64.sh
+    curl -Os http://repo.continuum.io/miniconda/Miniconda3-${CONDA_VERSION}-Linux-x86_64.sh
     bash Miniconda-${CONDA_VERSION}-Linux-x86_64.sh -p /app/.heroku/miniconda/ -b | indent
     rm -fr Miniconda-${CONDA_VERSION}-Linux-x86_64.sh
 

--- a/bin/steps/conda_compile
+++ b/bin/steps/conda_compile
@@ -9,7 +9,7 @@ if [ ! -d /app/.heroku/miniconda ]; then
     conda update conda --quiet --yes | indent
 fi
 
-conda env --help || conda update conda --quiet --yes | indent
+(puts-setp "Checking for conda env" && conda env &> /dev/null) || conda update conda --quiet --yes | indent
 
 if [ -f conda-requirements.txt ]; then
     puts-step "Installing dependencies using Conda"

--- a/bin/steps/conda_compile
+++ b/bin/steps/conda_compile
@@ -23,9 +23,9 @@ if [ -f environment.yml ]; then
     conda env remove --yes --quiet --name heroku-env || puts-step "No old environment to remove"
     conda env create --name=heroku-env --file environment.yml
     puts-step "Conda environment created"
-    conda activate heroku-env
-    conda install nomkl numpy
-    conda remove mkl mkl-service
+    source activate heroku-env
+    conda install --yes nomkl numpy
+    conda remove --yes mkl mkl-service
 fi
 
 # Clean up the installation environment .

--- a/bin/steps/conda_compile
+++ b/bin/steps/conda_compile
@@ -20,7 +20,7 @@ fi
 if [ -f environment.yml ]; then
     puts-step "Creating conda environment"
     # TODO: Use update if its already there
-    conda env remove --yes --quiet --name heroku-env
+    conda env remove --yes --quiet --name heroku-env || puts-step "No old environment to remove"
     conda env create --name=heroku-env --file environment.yml
 fi
 

--- a/bin/steps/conda_compile
+++ b/bin/steps/conda_compile
@@ -9,7 +9,7 @@ if [ ! -d /app/.heroku/miniconda ]; then
     conda update conda --quiet --yes | indent
 fi
 
-(puts-setp "Checking for conda env" && conda env &> /dev/null) || conda update conda --quiet --yes | indent
+(puts-step "Checking for conda env" && conda env &> /dev/null) || conda update conda --quiet --yes | indent
 
 if [ -f conda-requirements.txt ]; then
     puts-step "Installing dependencies using Conda"

--- a/bin/steps/conda_compile
+++ b/bin/steps/conda_compile
@@ -21,7 +21,7 @@ if [ -f environment.yml ]; then
     puts-step "Creating conda environment"
     # TODO: Use update if its already there
     conda env remove --yes --quiet --name heroku-env
-    conda env create --name=heroku-env --file environment.yml
+    conda env create -v --name=heroku-env --file environment.yml
 fi
 
 # Clean up the installation environment .

--- a/bin/steps/conda_compile
+++ b/bin/steps/conda_compile
@@ -24,7 +24,7 @@ if [ -f environment.yml ]; then
     conda env create --name=heroku-env --file environment.yml
     puts-step "Conda environment created"
     source activate heroku-env
-    conda install --yes nomkl numpy
+    # conda install --yes nomkl numpy
     conda remove --yes mkl mkl-service
 fi
 

--- a/bin/steps/conda_compile
+++ b/bin/steps/conda_compile
@@ -22,6 +22,10 @@ if [ -f environment.yml ]; then
     # TODO: Use update if its already there
     conda env remove --yes --quiet --name heroku-env || puts-step "No old environment to remove"
     conda env create --name=heroku-env --file environment.yml
+    puts-step "Conda environment created"
+    conda activate heroku-env
+    conda install nomkl numpy
+    conda remove mkl mkl-service
 fi
 
 # Clean up the installation environment .

--- a/bin/steps/conda_compile
+++ b/bin/steps/conda_compile
@@ -4,8 +4,8 @@ puts-step "Checking for existing conda install"
 if [ ! -d /app/.heroku/miniconda ]; then
     puts-step "Preparing Python/Miniconda Environment (${CONDA_VERSION})"
     curl -Os http://repo.continuum.io/miniconda/Miniconda3-${CONDA_VERSION}-Linux-x86_64.sh
-    bash Miniconda-${CONDA_VERSION}-Linux-x86_64.sh -p /app/.heroku/miniconda/ -b | indent
-    rm -fr Miniconda-${CONDA_VERSION}-Linux-x86_64.sh
+    bash Miniconda3-${CONDA_VERSION}-Linux-x86_64.sh -p /app/.heroku/miniconda/ -b | indent
+    rm -fr Miniconda3-${CONDA_VERSION}-Linux-x86_64.sh
 
     conda update conda --quiet --yes | indent
 fi

--- a/bin/steps/conda_compile
+++ b/bin/steps/conda_compile
@@ -3,7 +3,7 @@ CONDA_VERSION=4.3.31
 puts-step "Checking for existing conda install"
 if [ ! -d /app/.heroku/miniconda ]; then
     puts-step "Preparing Python/Miniconda Environment (${CONDA_VERSION})"
-    curl -Os http://repo.continuum.io/miniconda/Miniconda3-${CONDA_VERSION}-Linux-x86_64.sh
+    curl -Os https://repo.continuum.io/miniconda/Miniconda3-${CONDA_VERSION}-Linux-x86_64.sh
     bash Miniconda3-${CONDA_VERSION}-Linux-x86_64.sh -p /app/.heroku/miniconda/ -b | indent
     rm -fr Miniconda3-${CONDA_VERSION}-Linux-x86_64.sh
 

--- a/bin/steps/conda_compile
+++ b/bin/steps/conda_compile
@@ -9,7 +9,7 @@ if [ ! -d /app/.heroku/miniconda ]; then
     conda update conda --quiet --yes | indent
 fi
 
-conda environment --help || conda update conda --quiet --yes | indent
+conda env --help || conda update conda --quiet --yes | indent
 
 if [ -f conda-requirements.txt ]; then
     puts-step "Installing dependencies using Conda"


### PR DESCRIPTION
Thanks for making a buildpack that uses environments!

I was upgrading from the original conda buildpack and ran into an issue because it had a version of conda installed pre-conda-env.

This PR adds a line that checks for `conda env` and updates conda if it isn't present.
